### PR TITLE
Dev

### DIFF
--- a/ModForge.Shared/Services/IconService.cs
+++ b/ModForge.Shared/Services/IconService.cs
@@ -45,7 +45,20 @@ namespace ModForge.Shared.Services
 
 		public string? GetBase64Icon(string iconId, string matchingFolder = null!)
 		{
+			if (string.IsNullOrEmpty(configService.Current.GameDirectory))
+			{
+				logger.LogWarning("Game directory is not configured. Cannot load icon: {IconId}", iconId);
+				return null;
+			}
+
 			string pakPath = Path.Combine(configService.Current.GameDirectory, "Data", "IPL_GameData.pak");
+
+			if (!File.Exists(pakPath))
+			{
+				logger.LogWarning("Game data file not found at: {PakPath}", pakPath);
+				return null;
+			}
+
 			string targetFilename = $"{iconId}";
 
 			using FileStream zipStream = new(pakPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);

--- a/ModForge.Shared/Services/ModService.cs
+++ b/ModForge.Shared/Services/ModService.cs
@@ -72,6 +72,13 @@ namespace ModForge.Shared.Services
 			}
 
 			var modFolder = Path.Combine(userConfigurationService.Current.GameDirectory, "Mods");
+
+			if (!Directory.Exists(modFolder))
+			{
+				Directory.CreateDirectory(modFolder);
+				logger.LogInformation("Created Mods folder at: {ModFolder}", modFolder);
+			}
+
 			var modDirectories = Directory.EnumerateDirectories(modFolder);
 
 			ModCollection.Clear();
@@ -229,6 +236,12 @@ namespace ModForge.Shared.Services
 			}
 
 			var modFolder = Path.Combine(userConfigurationService.Current.GameDirectory, "Mods");
+
+			if (!Directory.Exists(modFolder))
+			{
+				return; // Nothing to delete if Mods folder doesn't exist
+			}
+
 			var modDirectories = Directory.EnumerateDirectories(modFolder);
 
 			foreach (var modPath in modDirectories)

--- a/ModForge.Shared/Services/XmlService.cs
+++ b/ModForge.Shared/Services/XmlService.cs
@@ -45,8 +45,8 @@ namespace ModForge.Shared.Services
 		}
 
 		#region Properties
-		public IList<IModItem> Perks { get; private set; }
-		public IList<IModItem> Buffs { get; private set; }
+		public IList<IModItem> Perks { get; private set; } = new List<IModItem>();
+		public IList<IModItem> Buffs { get; private set; } = new List<IModItem>();
 		public IList<IModItem> Weapons { get; private set; } = new List<IModItem>();
 		public IList<IModItem> Armors { get; private set; } = new List<IModItem>();
 		public IList<IModItem> Consumeables { get; private set; } = new List<IModItem>();

--- a/ModForge.UI/Components/MenuComponents/NewMod.razor.cs
+++ b/ModForge.UI/Components/MenuComponents/NewMod.razor.cs
@@ -107,6 +107,13 @@ namespace ModForge.UI.Components.MenuComponents
 				return;
 			}
 
+			if (string.IsNullOrEmpty(UserConfigurationService?.Current?.GameDirectory))
+			{
+				Logger?.LogWarning("Game directory is not configured. Cannot start modding.");
+				Snackbar?.Add("Please configure your game directory in Settings before starting a mod.", Severity.Error);
+				return;
+			}
+
 			var mod = ModService.CreateNewMod(name, description, author, version, createdOn, modId, modifiesLevel, supportedGameVersions);
 
 			if (mod is null)

--- a/ModForge.UI/Components/ModItemComponents/Armors.razor.cs
+++ b/ModForge.UI/Components/ModItemComponents/Armors.razor.cs
@@ -206,7 +206,7 @@ namespace ModForge.UI.Components.ModItemComponents
 		{
 			SetLanguage();
 			ModService.TryGetModFromCollection(ModId);
-			armors = await Task.Run(() => XmlService.Armors.ToList());
+			armors = await Task.Run(() => XmlService.Armors?.ToList() ?? new List<IModItem>());
 			isLoaded = true;
 		}
 

--- a/ModForge.UI/Components/ModItemComponents/Buffs.razor.cs
+++ b/ModForge.UI/Components/ModItemComponents/Buffs.razor.cs
@@ -214,7 +214,7 @@ namespace ModForge.UI.Components.ModItemComponents
 		{
 			SetLanguage();
 			ModService.TryGetModFromCollection(ModId);
-			buffs = await Task.Run(() => XmlService.Buffs.ToList());
+			buffs = await Task.Run(() => XmlService.Buffs?.ToList() ?? new List<IModItem>());
 			isLoaded = true;
 		}
 	}

--- a/ModForge.UI/Components/ModItemComponents/Consumables.razor.cs
+++ b/ModForge.UI/Components/ModItemComponents/Consumables.razor.cs
@@ -223,7 +223,7 @@ namespace ModForge.UI.Components.ModItemComponents
 		{
 			SetLanguage();
 			ModService.TryGetModFromCollection(ModId);
-			consumables = await Task.Run(() => XmlService.Consumeables.ToList());
+			consumables = await Task.Run(() => XmlService.Consumeables?.ToList() ?? new List<IModItem>());
 			isLoaded = true;
 		}
 	}

--- a/ModForge.UI/Components/ModItemComponents/CraftingMaterials.razor.cs
+++ b/ModForge.UI/Components/ModItemComponents/CraftingMaterials.razor.cs
@@ -223,7 +223,7 @@ namespace ModForge.UI.Components.ModItemComponents
 		{
 			SetLanguage();
 			ModService.TryGetModFromCollection(ModId);
-			craftingMaterials = await Task.Run(() => XmlService.CraftingMaterials.ToList());
+			craftingMaterials = await Task.Run(() => XmlService.CraftingMaterials?.ToList() ?? new List<IModItem>());
 			isLoaded = true;
 		}
 	}

--- a/ModForge.UI/Components/ModItemComponents/MiscItems.razor.cs
+++ b/ModForge.UI/Components/ModItemComponents/MiscItems.razor.cs
@@ -223,7 +223,7 @@ namespace ModForge.UI.Components.ModItemComponents
 		{
 			SetLanguage();
 			ModService.TryGetModFromCollection(ModId);
-			miscItems = await Task.Run(() => XmlService.MiscItems.ToList());
+			miscItems = await Task.Run(() => XmlService.MiscItems?.ToList() ?? new List<IModItem>());
 			isLoaded = true;
 		}
 	}

--- a/ModForge.UI/Components/ModItemComponents/Perks.razor.cs
+++ b/ModForge.UI/Components/ModItemComponents/Perks.razor.cs
@@ -224,7 +224,7 @@ namespace ModForge.UI.Components.ModItemComponents
 		{
 			SetLanguage();
 			ModService.TryGetModFromCollection(ModId);
-			perks = await Task.Run(() => XmlService.Perks.ToList());
+			perks = await Task.Run(() => XmlService.Perks?.ToList() ?? new List<IModItem>());
 			isLoaded = true;
 		}
 	}

--- a/ModForge.UI/Components/ModItemComponents/Weapons.razor.cs
+++ b/ModForge.UI/Components/ModItemComponents/Weapons.razor.cs
@@ -223,7 +223,7 @@ namespace ModForge.UI.Components.ModItemComponents
 		{
 			SetLanguage();
 			ModService.TryGetModFromCollection(ModId);
-			weapons = await Task.Run(() => XmlService.Weapons.ToList());
+			weapons = await Task.Run(() => XmlService.Weapons?.ToList() ?? new List<IModItem>());
 			isLoaded = true;
 		}
 	}


### PR DESCRIPTION
## Summary
Fix application crash when user clicks "Start Modding" without having configured the game directory.

When the application is first downloaded, the game directory is not configured by default. Additionally, fresh game installations don't have a "Mods" folder. Attempting to create a new mod in this state caused the application to crash due to:
- `ArgumentNullException` from null Perks/Buffs collections in XmlService
- `DirectoryNotFoundException` in IconService looking for pak files in wrong location
- `DirectoryNotFoundException` in ModService when Mods folder doesn't exist

## Changes
- Initialize Perks and Buffs collections with empty lists in XmlService
- Add GameDirectory and file existence checks in IconService.GetBase64Icon
- Validate game directory in NewMod.StartModding with user-friendly snackbar error
- Add null-safe access to XmlService collections in all ModItem components
- Create Mods folder automatically if it doesn't exist in InitiateModCollections
- Skip mod enumeration in DeleteMod if Mods folder doesn't exist

## Test plan
- [x] Launch app without game directory configured
- [x] Create a new mod and click "Start Modding"
- [x] Verify error message appears instead of crash
- [x] Configure game directory in Settings
- [x] Verify modding flow works normally with fresh game install (no Mods folder)

This resolves "Unset Game Direct cause the crash when create new mod." on [nexusmods](https://www.nexusmods.com/kingdomcomedeliverance2/mods/2142?tab=bugs)